### PR TITLE
Include disk cache and current memory options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.cov
 terraform-provider-libvirt
 .terraform
+.idea

--- a/libvirt/domain.go
+++ b/libvirt/domain.go
@@ -597,7 +597,9 @@ func setDisks(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *lib
 
 			disk.Driver.Type = "raw"
 		}
-
+		if cache, ok := d.GetOk(prefix + ".cache"); ok && cache != "" {
+			disk.Driver.Cache = cache.(string)
+		}
 		domainDef.Devices.Disks = append(domainDef.Devices.Disks, disk)
 	}
 

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -60,6 +60,11 @@ func resourceLibvirtVolume() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"cache": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"xml": {
 				Type:     schema.TypeList,
 				Optional: true,


### PR DESCRIPTION
- Adding disk cache mode for using with LVM (block devices)
- Adding option to configure current memory volume.


Please make sure you read [the contributor documentation](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/CONTRIBUTING.md) before opening a Pull Request.
